### PR TITLE
Add fitting function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 [compat]
 CoordinateTransformations = "0.6"
 KeywordCalls = "0.2"
+Optim = "1"
 RecipesBase = "1"
 Rotations = "1"
 SpecialFunctions = "0.10, 1, 2"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.5.0"
 [deps]
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 KeywordCalls = "4d827475-d3e4-43d6-abe3-9688362ede9f"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 CoordinateTransformations = "0.6"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ First, load the package
 julia> using PSFModels
 ```
 
+### Evaluating models
+
 Directly evaluating the functions is the most straightforward way to use this package
 
 ```julia
@@ -125,6 +127,43 @@ or we can create a loss function for fitting PSFs without allocating any memory.
 julia> using Statistics
 
 julia> mse = mean(I -> (big_img[I] - model(I))^2, CartesianIndices(stamp_inds));
+```
+
+### Fitting data
+
+There exists a simple, yet powerful, API for fitting data with these PSF models. See the [full documentation](https://juliaastro.github.io/PSFModels.jl/dev) for more details and examples.
+
+```julia
+# `fit` is not exported to avoid namespace clashes
+using PSFModels: fit
+
+data = # load data
+stamp_inds = # optionally choose indices to "cutout"
+
+# use an isotropic Gaussian
+params, synthpsf = fit(gaussian, (:x, :y, :fwhm, :amp), 
+                       [12, 13, 3.2, 0.1], data, stamp_inds)
+# elliptical, rotated Gaussian
+params, synthpsf = fit(gaussian, (:x, :y, :fwhm, :amp, :theta), 
+                       [12, 13, 3.2, 3.2, 0.1, 0], data, stamp_inds)
+# obscured Airy disk
+params, synthpsf = fit(airydisk, (:x, :y, :fwhm, :amp, :ratio),
+                       [12, 13, 3.2, 0.1, 0.3], data, stamp_inds)
+# bivariate Moffat with arbitrary alpha
+params, synthpsf = fit(moffat, (:x, :y, :fwhm, :amp, :alpha),
+                       [12, 13, 3.2, 3.2, 0.1, 1], data, stamp_inds)
+```
+
+### Plotting models
+
+We provide simple user recipes from [RecipesBase.jl](https://github.com/JuliaPlots/RecipesBase.jl), which can be called with `psfplot`/`psfplot!`
+
+```julia
+using Plots
+
+inds = (1:30, 1:30)
+model = airydisk(x=12, y=13, fwhm=(4.5, 6.7), theta=12, ratio=0.3)
+psfplot(model, inds, colorbar_scale=:log10)
 ```
 
 ## Contributing and Support

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -67,3 +67,9 @@ plot(
     xlabel="x", ylabel="I", ylims=(1e-5, 1)
 )
 ```
+
+## Fitters
+
+```@docs
+PSFModels.fit
+```

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -37,6 +37,7 @@ Using [`gaussian`](@ref)
 ```@example fit
 # parameter vector must match order of values we want to fit
 params = (:x, :y, :fwhm, :amp)
+# x, y, fwhm, amp
 P0 = Float32[20, 20, 5, 0.1]
 P_gauss, mod_gauss = fit(gaussian, params, P0, psf)
 pairs(P_gauss)
@@ -60,7 +61,8 @@ and now using a rotated, elliptical Gaussian
 ```@example fit
 # parameter vector must match order of values we want to fit
 params = (:x, :y, :fwhm, :amp, :theta)
-# use two values for theta here, one for each axis
+# use two values for fwhm here, one for each axis
+# x, y, fwhmx, fwhmy, amp, theta
 P0 = Float32[20, 20, 5, 5, 0.1, 0]
 P_ellip, mod_ellip = fit(gaussian, params, P0, psf)
 pairs(P_ellip)
@@ -136,11 +138,10 @@ plot(
 Any keyword arguments get passed on to `Optim.optimize`, and you can change the algorithm used with the `alg` keyword
 
 ```@example fit
+# load Optim.jl to use the Newton method
 using Optim
 
-# parameter vector must match order of values we want to fit
 params = (:x, :y, :fwhm, :amp, :theta, :alpha)
-# again, two values for fwhm for each axis
 P0 = Float32[20, 20, 5, 5, 0.1, 0, 2]
 P_moff, mod_moff = fit(moffat, params, P0, psf; alg=Newton())
 pairs(P_moff)

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -7,6 +7,7 @@ Here is a brief example which shows how to construct a loss function for fitting
 
 ```@example fit
 using PSFModels
+using PSFModels: fit
 using HCIDatasets: BetaPictoris
 using Plots
 using Statistics
@@ -15,7 +16,8 @@ using Statistics
 function imshow(data; kwargs...)
     xlim = extrema(axes(data, 1))
     ylim = extrema(axes(data, 2))
-    heatmap(transpose(data); xlim=xlim, ylim=ylim, aspect_ratio=1, kwargs...)
+    heatmap(transpose(data); xlim=xlim, ylim=ylim,
+            aspect_ratio=1, clims=(1e-5, Inf), kwargs...)
 end
 
 # get a PSF from HCIDatasets.jl;
@@ -25,60 +27,25 @@ psf = BetaPictoris[:psf]
 imshow(psf)
 ```
 
-```@example fit
-# generative model
-function model(X::AbstractVector{T}) where T
-    x    =       X[1]   # position
-    y    =       X[2]
-    fwhm = @view X[3:4] # fwhm_x, fwhm_y
-    amp  =       X[5]   # amplitude
-    return airydisk(T; x, y, fwhm, amp)
-end
+We can fit this data with a variety of models, here showcasing the flexible [`PSFModels.fit`](@ref) function.
 
-# objective function
-function loss(X::AbstractVector{T}, target) where T
-    # cheap way to enforce positivity
-    all(>(0), X) || return T(Inf)
-    # get generative model
-    m = model(X)
-    # mean square error
-    return mean(idx -> (m(idx) - psf[idx])^2, CartesianIndices(psf))
-end
 
-# params are [x, y, fwhm_x, fwhm_y, amp]
-test_params = eltype(psf)[20, 20, 5, 5, 1]
-loss(test_params, psf)
-```
+### Gaussian
 
-The objective function can then be used with an optimization library like [Optim.jl](https://github.com/JuliaOpt/Optim.jl) to find best-fitting parameters
+Using [`gaussian`](@ref)
 
 ```@example fit
-using Optim
-
-# Fit our data using test_params as a starting point
-# uses Nelder-Mead optimization
-res = optimize(P -> loss(P, psf), test_params)
+# parameter vector must match order of values we want to fit
+params = (:x, :y, :fwhm, :amp)
+P0 = Float32[20, 20, 5, 0.1]
+P_gauss, mod_gauss = fit(gaussian, params, P0, psf)
+pairs(P_gauss)
 ```
 
 ```@example fit
-# utilize automatic differentiation (AD) to enable
-# advanced algorithms, like LBFGS
-res_ad = optimize(P -> loss(P, psf), test_params, LBFGS(); autodiff=:forward)
-```
-
-we can see which result has the better loss, and then use the generative model to create a model that we can use elsewhere
-
-```@example fit
-best_res = minimum(res) < minimum(res_ad) ? res : res_ad
-best_fit_params = Optim.minimizer(best_res)
-```
-
-```@example fit
-synth_psf = model(best_fit_params)
-
 plot(
     imshow(psf, title="Data"),
-    psfplot(synth_psf, axes(psf); title="Model"),
+    imshow(mod_gauss, title="Model"),
     cbar=false,
     ticks=false,
     xlabel="",
@@ -86,4 +53,95 @@ plot(
     layout=2,
     size=(600, 300)
 )
+```
+
+and now using a rotated, elliptical Gaussian
+
+```@example fit
+# parameter vector must match order of values we want to fit
+params = (:x, :y, :fwhm, :amp, :theta)
+# use two values for theta here, one for each axis
+P0 = Float32[20, 20, 5, 5, 0.1, 0]
+P_ellip, mod_ellip = fit(gaussian, params, P0, psf)
+pairs(P_ellip)
+```
+
+```@example fit
+plot(
+    imshow(psf, title="Data"),
+    imshow(mod_ellip, title="Model"),
+    cbar=false,
+    ticks=false,
+    xlabel="",
+    ylabel="",
+    layout=2,
+    size=(600, 300)
+)
+```
+
+### Airy disk
+
+Now with [`airydisk`](@ref)
+
+```@example fit
+# parameter vector must match order of values we want to fit
+params = (:x, :y, :fwhm, :amp, :ratio)
+P0 = Float32[20, 20, 5, 0.1, 0.3]
+P_airy, mod_airy = fit(airydisk, params, P0, psf)
+pairs(P_airy)
+```
+
+```@example fit
+plot(
+    imshow(psf, title="Data"),
+    imshow(mod_airy, title="Model"),
+    cbar=false,
+    ticks=false,
+    xlabel="",
+    ylabel="",
+    layout=2,
+    size=(600, 300)
+)
+```
+
+### Moffat
+
+And finally, with [`moffat`](@ref)
+
+
+```@example fit
+# parameter vector must match order of values we want to fit
+params = (:x, :y, :fwhm, :amp, :theta, :alpha)
+# again, two values for fwhm for each axis
+P0 = Float32[20, 20, 5, 5, 0.1, 0, 2]
+P_moff, mod_moff = fit(moffat, params, P0, psf)
+pairs(P_moff)
+```
+
+```@example fit
+plot(
+    imshow(psf, title="Data"),
+    imshow(mod_moff, title="Model"),
+    cbar=false,
+    ticks=false,
+    xlabel="",
+    ylabel="",
+    layout=2,
+    size=(600, 300)
+)
+```
+
+### Changing optimization parameters
+
+Any keyword arguments get passed on to `Optim.optimize`, and you can change the algorithm used with the `alg` keyword
+
+```@example fit
+using Optim
+
+# parameter vector must match order of values we want to fit
+params = (:x, :y, :fwhm, :amp, :theta, :alpha)
+# again, two values for fwhm for each axis
+P0 = Float32[20, 20, 5, 5, 0.1, 0, 2]
+P_moff, mod_moff = fit(moffat, params, P0, psf; alg=Newton())
+pairs(P_moff)
 ```

--- a/src/PSFModels.jl
+++ b/src/PSFModels.jl
@@ -16,6 +16,8 @@ In general, the PSFs have a position, a full-width at half-maximum (FWHM) measur
 
 ## Usage
 
+### Evaluating models
+
 Directly evaluating the functions is the most straightforward way to use this package
 
 ```jldoctest model
@@ -83,13 +85,40 @@ julia> using Statistics
 julia> mse = mean(I -> (big_img[I] - model(I))^2, CartesianIndices(stamp_inds));
 ```
 
-finally, we provide plotting recipes from [RecipesBase.jl](https://github.com/JuliaPlots/RecipesBase.jl), which can be seen in use in the [API/Reference](@ref) section.
+### Fitting data
+
+There exists a simple, yet powerful, API for fitting data with [`PSFModels.fit`](@ref).
+
+```julia
+# `fit` is not exported to avoid namespace clashes
+using PSFModels: fit
+
+data = # load data
+stamp_inds = # optionally choose indices to "cutout"
+
+# use an isotropic Gaussian
+params, synthpsf = fit(gaussian, (:x, :y, :fwhm, :amp), 
+                       [12, 13, 3.2, 0.1], data, stamp_inds)
+# elliptical, rotated Gaussian
+params, synthpsf = fit(gaussian, (:x, :y, :fwhm, :amp, :theta), 
+                       [12, 13, 3.2, 3.2, 0.1, 0], data, stamp_inds)
+# obscured Airy disk
+params, synthpsf = fit(airydisk, (:x, :y, :fwhm, :amp, :ratio),
+                       [12, 13, 3.2, 0.1, 0.3], data, stamp_inds)
+# bivariate Moffat with arbitrary alpha
+params, synthpsf = fit(moffat, (:x, :y, :fwhm, :amp, :alpha),
+                       [12, 13, 3.2, 3.2, 0.1, 1], data, stamp_inds)
+```
+
+### Plotting
+
+Finally, we provide plotting recipes (`psfplot`/`psfplot!`) from [RecipesBase.jl](https://github.com/JuliaPlots/RecipesBase.jl), which can be seen in use in the [API/Reference](@ref) section.
 
 ```julia
 using Plots
-default(colorbar_scale=:log10)
+
 model = gaussian(x=0, y=0, fwhm=(8, 10), theta=12)
-psfplot(model, -30:30, -30:30)
+psfplot(model, -30:30, -30:30, colorbar_scale=:log10)
 ```
 """
 module PSFModels

--- a/src/PSFModels.jl
+++ b/src/PSFModels.jl
@@ -134,4 +134,6 @@ end
 _curried_point(P::BivariateLike) = P
 _curried_point(point...) = Tuple(point)
 
+include("fitting.jl")
+
 end # module PSFModels

--- a/src/PSFModels.jl
+++ b/src/PSFModels.jl
@@ -96,9 +96,11 @@ module PSFModels
 
 using CoordinateTransformations
 using KeywordCalls
+using Optim
 using Rotations
 using SpecialFunctions
 using StaticArrays
+using Statistics
 
 export gaussian, normal, airydisk, moffat
 

--- a/src/PSFModels.jl
+++ b/src/PSFModels.jl
@@ -41,7 +41,7 @@ If we want to collect the model into a dense matrix, simply iterate over indices
 julia> inds = CartesianIndices((-2:2, -2:2));
 
 julia> model.(inds) # broadcasting
-5x5 Matrix{Float64}:
+5×5 Matrix{Float64}:
  0.0850494  0.214311  0.291632  0.214311  0.0850494
  0.214311   0.54003   0.734867  0.54003   0.214311
  0.291632   0.734867  1.0       0.734867  0.291632
@@ -55,7 +55,7 @@ This makes it very easy to evaluate the PSF on the same axes as an image (array)
 julia> img = randn(5, 5);
 
 julia> model.(CartesianIndices(img))
-5x5 Matrix{Float64}:
+5×5 Matrix{Float64}:
  0.54003      0.214311     0.0459292    0.00531559   0.000332224
  0.214311     0.0850494    0.018227     0.00210949   0.000131843
  0.0459292    0.018227     0.00390625   0.000452087  2.82555e-5
@@ -89,7 +89,7 @@ finally, we provide plotting recipes from [RecipesBase.jl](https://github.com/Ju
 using Plots
 default(colorbar_scale=:log10)
 model = gaussian(x=0, y=0, fwhm=(8, 10), theta=12)
-psfplot(model, (-30:30, -30:30))              # default axes
+psfplot(model, -30:30, -30:30)
 ```
 """
 module PSFModels

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -1,7 +1,5 @@
-using Optim
-using Statistics
 
-Model = Union{typeof(gaussian), typeof(normal), typeof(airydisk), typeof(moffat)}
+const Model = Union{typeof(gaussian), typeof(normal), typeof(airydisk), typeof(moffat)}
 
 """
     PSFModels.fit(model, params, X0, image, inds=axes(image); alg=LBFGS(), kwargs...)
@@ -65,10 +63,10 @@ model = gaussian(; params...)
 
 `synthpsf` is the best-fitting model evaluated on the input grid, for direct comparison with the input data.
 """
-function fit(model::Model, params, X0, image::AbstractMatrix{T}, inds=axes(image); alg=LBFGS(), kwargs...) where T
+function fit(model::Model, params, X0::AbstractVector, image::AbstractMatrix{T}, inds=axes(image); alg=LBFGS(), kwargs...) where T
     if length(params) == length(X0) && :theta in params
         throw(ArgumentError("cannot fit theta for isotropic PSF"))
-   end
+    end
     cartinds = CartesianIndices(inds)
     function loss(X::AbstractVector{T}) where T
         P = generate_params(params, X)

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -1,0 +1,47 @@
+using Optim
+using Statistics
+
+Model = Union{typeof(gaussian), typeof(normal), typeof(airydisk), typeof(moffat)}
+
+function fit(model::Model, params, X0, image::AbstractMatrix{T}, inds=axes(image); alg=LBFGS(), kwargs...) where T
+    if length(params) == length(X0) && :theta in params
+        throw(ArgumentError("cannot fit theta for isotropic PSF"))
+   end
+    cartinds = CartesianIndices(inds)
+    function loss(X::AbstractVector{T}) where T
+        P = generate_params(params, X)
+        minind = map(minimum, inds)
+        maxind = map(maximum, inds)
+        minind[1] - 0.5 ≤ P.x ≤ maxind[1] + 0.5 || return T(Inf)
+        minind[2] - 0.5 ≤ P.y ≤ maxind[2] + 0.5 || return T(Inf)
+        all(>(0), P.fwhm) || return T(Inf)
+        if :ratio in params
+            0 < P.ratio < 1 || return T(Inf)
+        end
+        if :theta in params
+            -45 < P.theta < 45 || return T(Inf)
+        end
+        # mean square error
+        mse = mean(cartinds) do idx
+            resid = model(T, idx; P...) - image[idx]
+            return resid^2
+        end
+        return mse
+    end
+    result = optimize(loss, X0, alg; autodiff=:forward, kwargs...)
+    Optim.converged(result) || @warn "optimizer did not converge" result
+    X = Optim.minimizer(result)
+    P_best = generate_params(params, X)
+    return P_best, model.(T, cartinds; P_best...)
+end
+
+function generate_params(names, values)
+    if length(values) > length(names) && :fwhm in names
+        _ind = findfirst(==(:fwhm), names)
+        fwhm = values[_ind], values[_ind + 1]
+        first_half = @views zip(names[begin:_ind - 1], values[begin:_ind - 1])
+        second_half = @views zip(names[_ind + 1:end], values[_ind + 2:end])
+        return (;first_half..., fwhm, second_half...)        
+    end
+    return (;zip(names, values)...)
+end

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -3,6 +3,68 @@ using Statistics
 
 Model = Union{typeof(gaussian), typeof(normal), typeof(airydisk), typeof(moffat)}
 
+"""
+    PSFModels.fit(model, params, X0, image, inds=axes(image); alg=LBFGS(), kwargs...)
+
+Fit a PSF model (`model`) defined by the given `params` as a collection of symbols, and initial guess vector `X0`, to the data in `image` at the specified `inds` (by default, the entire array). Additional keyword arguments, as well as the fitting algorithm `alg`, are passed to `Optim.optimize`. By default we use forward-mode autodifferentiation (AD) to derive Jacobians for the fitting functions. Refer to the [Optim.jl documentation](https://julianlsolvers.github.io/Optim.jl/stable/) for more information.
+
+# Choosing parameters
+
+The `fit` function is very powerful because it gives you a great amount of flexibility in the way you fit your models. To demonstrate this, let's start with a simple isotropic [`gaussian`](@ref).
+
+```julia
+model = gaussian
+# match params to arguments of PSF
+params = (:x, :y, :fwhm, :amp)
+# initial-guess vector follows order of `params`
+X0 = [20, 20, 3, 1]
+```
+
+Note that `params` can follow any order
+
+```julia
+params = (:amp, :x, :y, :fwhm)
+X0 = [1, 20, 20, 3]
+```
+
+Now, to extend this interface to the bivariate PSF case, where `fwhm` is two values, all you need to do is add an additional entry in the appropriate position in the intial guess vector
+
+```julia
+params = (:x, :y, :fwhm)
+# x, y, fwhmx, fwhmy
+X0 = [20, 20, 3, 3]
+```
+
+and, again, the order does not matter
+
+```julia
+model = moffat
+params = (:alpha, :x, :y, :fwhm, :amp)
+# alpha, x, y, fwhmx, fwhmy, amp
+X0 = [1, 20, 20, 3, 3, 10]
+```
+    
+As of right now, the only thing you cannot do is "freeze" a parameter (to do that will require writing your own fitting methods and loss functions).
+
+# Fitting a PSF
+
+After selecting your model and parameters, fitting data is easy
+
+```julia
+P = (x=12, y=13, fwhm=13.2, amp=0.1)
+psf = gaussian.(CartesianIndicies(1:25, 1:15); P...)
+
+params, synthpsf = PSFModels.fit(gaussian, keys(P), values(P), psf)
+```
+
+here `params` is a named tuple of the best fitting parameters. This allows you to instantly create your best-fitting model like
+
+```julia
+model = gaussian(; params...)
+```
+
+`synthpsf` is the best-fitting model evaluated on the input grid, for direct comparison with the input data.
+"""
 function fit(model::Model, params, X0, image::AbstractMatrix{T}, inds=axes(image); alg=LBFGS(), kwargs...) where T
     if length(params) == length(X0) && :theta in params
         throw(ArgumentError("cannot fit theta for isotropic PSF"))

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,7 @@
 [deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/test/fitting.jl
+++ b/test/fitting.jl
@@ -40,12 +40,16 @@ end
         test_fitting(rng, gaussian, (x=13.5, y=12.3, fwhm=2.6, amp=5), inds)
         test_fitting(rng, gaussian, (x=13.5, y=12.3, fwhm=(2.6, 2.4), amp=5), inds)
         test_fitting(rng, gaussian, (x=13.5, y=12.3, fwhm=(2.6, 2.4), theta=12, amp=5), inds)
+
+        @test_throws ArgumentError fit(gaussian, (:x, :y, :fwhm, :theta), ones(4), randn(10, 10))
     end
     @testset "airydisk" begin
         test_fitting(rng, airydisk, (x=13.5, y=12.3, fwhm=2.6, amp=5), inds)
         test_fitting(rng, airydisk, (x=13.5, y=12.3, fwhm=2.6, amp=5, ratio=0.12), inds)
         test_fitting(rng, airydisk, (x=13.5, y=12.3, fwhm=(2.6, 2.4), amp=5), inds)
         test_fitting(rng, airydisk, (x=13.5, y=12.3, fwhm=(2.6, 2.4), theta=12, amp=5), inds)
+
+        @test_throws ArgumentError fit(airydisk, (:x, :y, :fwhm, :theta), ones(4), randn(10, 10))
     end
 
     @testset "moffat" begin
@@ -55,5 +59,7 @@ end
         test_fitting(rng, moffat, (x=13.5, y=12.3, fwhm=(2.6, 2.4), amp=5, alpha=1.2), inds)
         test_fitting(rng, moffat, (x=13.5, y=12.3, fwhm=(2.6, 2.4), theta=12, amp=5), inds)
         test_fitting(rng, moffat, (x=13.5, y=12.3, fwhm=(2.6, 2.4), theta=12, amp=5, alpha=1.2), inds)
+
+        @test_throws ArgumentError fit(moffat, (:x, :y, :fwhm, :theta), ones(4), randn(10, 10))
     end
 end

--- a/test/fitting.jl
+++ b/test/fitting.jl
@@ -1,0 +1,59 @@
+using PSFModels: fit
+
+
+function generate_model(rng, model, params, inds)
+    cartinds = CartesianIndices(inds)
+    psf = model.(cartinds; params...)
+    return psf
+end
+
+function test_fitting(rng, model, params, inds; kwargs...)
+    psf = generate_model(rng, model, params, inds)
+    _keys = keys(params)
+    if :fwhm in _keys && params.fwhm isa Tuple
+        _ind = findfirst(==(:fwhm), _keys)
+        vals = values(params)
+        first_half = vals[begin:_ind - 1]
+        fwhmx, fwhmy = vals[_ind]
+        second_half = vals[_ind + 1:end]
+        _vals = Float64[first_half..., fwhmx, fwhmy, second_half...]
+    else
+        _vals = collect(Float64, values(params))
+    end
+    # perturb starting guess by a little
+    _vals .*= 1 .+ 1e-2 .* randn(rng, length(_vals))
+    P, bestfit = fit(model, _keys, _vals, psf; kwargs...)
+    for k in _keys
+        if P[k] isa Tuple
+            @test P[k][1] ≈ params[k][1] rtol=1e-6
+            @test P[k][2] ≈ params[k][2] rtol=1e-6
+        else
+            @test P[k] ≈ params[k] rtol=1e-6
+        end
+    end
+    @test bestfit ≈ psf rtol=1e-6
+end
+
+@testset "test fitting synthetic PSFs" begin
+    inds = 1:30, 1:30
+    @testset "gaussian" begin
+        test_fitting(rng, gaussian, (x=13.5, y=12.3, fwhm=2.6, amp=5), inds)
+        test_fitting(rng, gaussian, (x=13.5, y=12.3, fwhm=(2.6, 2.4), amp=5), inds)
+        test_fitting(rng, gaussian, (x=13.5, y=12.3, fwhm=(2.6, 2.4), theta=12, amp=5), inds)
+    end
+    @testset "airydisk" begin
+        test_fitting(rng, airydisk, (x=13.5, y=12.3, fwhm=2.6, amp=5), inds)
+        test_fitting(rng, airydisk, (x=13.5, y=12.3, fwhm=2.6, amp=5, ratio=0.12), inds)
+        test_fitting(rng, airydisk, (x=13.5, y=12.3, fwhm=(2.6, 2.4), amp=5), inds)
+        test_fitting(rng, airydisk, (x=13.5, y=12.3, fwhm=(2.6, 2.4), theta=12, amp=5), inds)
+    end
+
+    @testset "moffat" begin
+        test_fitting(rng, moffat, (x=13.5, y=12.3, fwhm=2.6, amp=5), inds)
+        test_fitting(rng, moffat, (x=13.5, y=12.3, fwhm=2.6, amp=5, alpha=1.2), inds)
+        test_fitting(rng, moffat, (x=13.5, y=12.3, fwhm=(2.6, 2.4), amp=5), inds)
+        test_fitting(rng, moffat, (x=13.5, y=12.3, fwhm=(2.6, 2.4), amp=5, alpha=1.2), inds)
+        test_fitting(rng, moffat, (x=13.5, y=12.3, fwhm=(2.6, 2.4), theta=12, amp=5), inds)
+        test_fitting(rng, moffat, (x=13.5, y=12.3, fwhm=(2.6, 2.4), theta=12, amp=5, alpha=1.2), inds)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,10 @@
+using Distributions
 using PSFModels
+using StableRNGs
 using StaticArrays
 using Test
+
+rng = StableRNG(112358)
 
 modname(::typeof(gaussian)) = "gaussian"
 modname(::typeof(airydisk)) = "airydisk"
@@ -131,3 +135,4 @@ end
 end
 
 include("plotting.jl")
+include("fitting.jl")


### PR DESCRIPTION
- add fitter code using Optim.jl
- update examples to use fitters
- get fitting tests working


This introduces a `PSFModels.fit` interface, which I've tested and works _pretty well_. Take a look at the new docs examples for an example. I've added a bunch of tests that just generate a PSF using a given model, then tries to retrieve the parameters.

This interface allows fitting stamps of larger images, too, without a problem. The only thing it can't do is "freeze" parameters.

This is a somewhat major change, since now `Optim.jl` has to be shipped with the package, but as I mentioned in #5 this functionality can be split into a separate package *if there is sufficient desire from users* (including myself).

This is pretty exciting for me, since this is going to improve the usability of this package ten-fold for me. It's also very easy to swap in and out models for rapid experimentation. 
