### PR TITLE
switch fitters to use named tuples

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -772,10 +772,10 @@ uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
 version = "0.11.5"
 
 [[deps.PSFModels]]
-deps = ["CoordinateTransformations", "KeywordCalls", "RecipesBase", "Rotations", "SpecialFunctions", "StaticArrays"]
+deps = ["CoordinateTransformations", "KeywordCalls", "Optim", "RecipesBase", "Rotations", "SpecialFunctions", "StaticArrays", "Statistics"]
 path = ".."
 uuid = "9ba017d1-7760-46cd-84a3-1e79e9ae9ddc"
-version = "0.5.0"
+version = "0.5.1"
 
 [[deps.Parameters]]
 deps = ["OrderedCollections", "UnPack"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,6 +21,7 @@ makedocs(;
     pages=[
         "Home" => "index.md",
         "Examples" => "examples.md",
+        "Benchmarks" => "bench.md",
         "API/Reference" => "api.md",
     ],
 )

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -62,7 +62,7 @@ psfplot(moff2, -50:50, -50:50; title="moffat(fwhm=10, alpha=2)",
 ```@example plots
 xs = range(0, 50, length=1000)
 plot(
-    xs, [gauss.(xs, 0) airy.(xs, 0) moff.(xs, 0)], 
+    xs, [gauss.(xs, 0) airy.(xs, 0) moff.(xs, 0)],
     label=["gaussian" "airydisk" "moffat"], yscale=:log10,
     xlabel="x", ylabel="I", ylims=(1e-5, 1)
 )

--- a/docs/src/bench.md
+++ b/docs/src/bench.md
@@ -1,0 +1,57 @@
+# Benchmarks
+
+The benchmarks can be found in the [`bench/`](https://github.com/JuliaAstro/PSFModels.jl/tree/main/bench) folder. To run them, first install the python dependencies
+
+```
+$ cd bench
+$ poetry install
+$ poetry shell
+```
+then get the Julia project set up
+```
+$ PYTHON=$(which python) julia --project=@. -e 'using Pkg; Pkg.instantiate(); Pkg.build("PyCall")'
+```
+
+Then run the benchmark
+
+```
+$ julia --project=. bench.jl
+```
+
+**System Information**
+
+```
+Julia Version 1.6.0
+Commit f9720dc2eb* (2021-03-24 12:55 UTC)
+Platform Info:
+  OS: macOS (x86_64-apple-darwin20.3.0)
+  CPU: Intel(R) Core(TM) i5-8259U CPU @ 2.30GHz
+  WORD_SIZE: 64
+  LIBM: libopenlibm
+  LLVM: libLLVM-11.0.1 (ORCJIT, skylake)
+Environment:
+  JULIA_NUM_THREADS = 1
+```
+
+---
+
+### Evaluation benchmark
+
+This benchmark tests how long it takes to evaluate a single point in the PSF model. This may seem contrived, but we expect performance to scale directly from this measure: if it takes 1 microsecond to evaluate a single point, it should take ~1 second to evaluate a 1000x1000 image, with speedups potentially from multithreading or SIMD loop evaluation.
+
+```@setup bench
+using CSV, DataFrames
+using StatsPlots
+benchdir(args...) = joinpath("..", ".." ,"bench", args...);
+```
+
+
+```@example bench
+table = CSV.File(benchdir("results.csv")) |> DataFrame
+```
+
+```@example bench
+@df table groupedbar(:name, [:psfmodels :astropy];
+    ylabel="time (s)", yscale=:log10, leg=:outertopright,
+    label=["PSFModels.jl" "Astropy"], size=(500, 300))
+```

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -35,11 +35,8 @@ We can fit this data with a variety of models, here showcasing the flexible [`PS
 Using [`gaussian`](@ref)
 
 ```@example fit
-# parameter vector must match order of values we want to fit
-params = (:x, :y, :fwhm, :amp)
-# x, y, fwhm, amp
-P0 = Float32[20, 20, 5, 0.1]
-P_gauss, mod_gauss = fit(gaussian, params, P0, psf)
+params = (x=20, y=20, fwhm=5, amp=0.1)
+P_gauss, mod_gauss = fit(gaussian, params, psf)
 pairs(P_gauss)
 ```
 
@@ -59,12 +56,8 @@ plot(
 and now using a rotated, elliptical Gaussian
 
 ```@example fit
-# parameter vector must match order of values we want to fit
-params = (:x, :y, :fwhm, :amp, :theta)
-# use two values for fwhm here, one for each axis
-# x, y, fwhmx, fwhmy, amp, theta
-P0 = Float32[20, 20, 5, 5, 0.1, 0]
-P_ellip, mod_ellip = fit(gaussian, params, P0, psf)
+params = (x=20, y=20, fwhm=(5, 5), amp=0.1, theta=0)
+P_ellip, mod_ellip = fit(gaussian, params, psf)
 pairs(P_ellip)
 ```
 
@@ -86,10 +79,8 @@ plot(
 Now with [`airydisk`](@ref)
 
 ```@example fit
-# parameter vector must match order of values we want to fit
-params = (:x, :y, :fwhm, :amp, :ratio)
-P0 = Float32[20, 20, 5, 0.1, 0.3]
-P_airy, mod_airy = fit(airydisk, params, P0, psf)
+params = (x=20, y=20, fwhm=5, amp=0.1, ratio=0.3)
+P_airy, mod_airy = fit(airydisk, params, psf)
 pairs(P_airy)
 ```
 
@@ -112,11 +103,8 @@ And finally, with [`moffat`](@ref)
 
 
 ```@example fit
-# parameter vector must match order of values we want to fit
-params = (:x, :y, :fwhm, :amp, :theta, :alpha)
-# again, two values for fwhm for each axis
-P0 = Float32[20, 20, 5, 5, 0.1, 0, 2]
-P_moff, mod_moff = fit(moffat, params, P0, psf)
+params = (x=20, y=20, fwhm=(5, 5), amp=0.1, theta=0, alpha=2)
+P_moff, mod_moff = fit(moffat, params, psf)
 pairs(P_moff)
 ```
 
@@ -141,8 +129,30 @@ Any keyword arguments get passed on to `Optim.optimize`, and you can change the 
 # load Optim.jl to use the Newton method
 using Optim
 
-params = (:x, :y, :fwhm, :amp, :theta, :alpha)
-P0 = Float32[20, 20, 5, 5, 0.1, 0, 2]
-P_moff, mod_moff = fit(moffat, params, P0, psf; alg=Newton())
+params = (x=20, y=20, fwhm=(5, 5), amp=0.1, theta=0, alpha=2)
+P_moff, mod_moff = fit(moffat, params, psf; alg=Newton())
 pairs(P_moff)
+```
+
+We can also "freeze" parameters by creating a named tuple and passing it to `func_kwargs`
+
+```@example fit
+
+params = (;x=10, y=20, fwhm=(5, 5), amp=0.1)
+func_kwargs = (;alpha=2)
+P_moff2, mod_moff2 = fit(moffat, params, psf;  func_kwargs)
+pairs(P_moff2)
+```
+
+```@example fit
+plot(
+    imshow(psf, title="Data"),
+    imshow(mod_moff2, title="Model"),
+    cbar=false,
+    ticks=false,
+    xlabel="",
+    ylabel="",
+    layout=2,
+    size=(600, 300)
+)
 ```

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -140,7 +140,7 @@ We can also "freeze" parameters by creating a named tuple and passing it to `fun
 
 params = (;x=10, y=20, fwhm=(5, 5), amp=0.1)
 func_kwargs = (;alpha=2)
-P_moff2, mod_moff2 = fit(moffat, params, psf;  func_kwargs)
+P_moff2, mod_moff2 = fit(moffat, params, psf; func_kwargs)
 pairs(P_moff2)
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -52,67 +52,6 @@ model = M.gaussian(x=0, y=0, fwhm=10)
 PSFModels
 ```
 
-## Benchmarks
-
-The benchmarks can be found in the [`bench/`](https://github.com/JuliaAstro/PSFModels.jl/tree/main/bench) folder. To run them, first install the python dependencies
-
-```
-$ cd bench
-$ poetry install
-$ poetry shell
-```
-then get the Julia project set up
-```
-$ PYTHON=$(which python) julia --project=@. -e 'using Pkg; Pkg.instantiate(); Pkg.build("PyCall")'
-```
-
-Then run the benchmark
-
-```
-$ julia --project=. bench.jl
-```
-
-**System Information**
-
-```
-Julia Version 1.6.0
-Commit f9720dc2eb* (2021-03-24 12:55 UTC)
-Platform Info:
-  OS: macOS (x86_64-apple-darwin20.3.0)
-  CPU: Intel(R) Core(TM) i5-8259U CPU @ 2.30GHz
-  WORD_SIZE: 64
-  LIBM: libopenlibm
-  LLVM: libLLVM-11.0.1 (ORCJIT, skylake)
-Environment:
-  JULIA_NUM_THREADS = 1
-```
-
----
-
-### Evaluation benchmark
-
-!!! warning "Out of date"
-  These benchmarks are out of date, but will be re-ran using the new, functional interface soon!
-
-This benchmark tests how long it takes to evaluate a single point in the PSF model. This may seem contrived, but we expect performance to scale directly from this measure: if it takes 1 microsecond to evaluate a single point, it should take ~1 second to evaluate a 1000x1000 image, with speedups potentially from multithreading or SIMD loop evaluation.
-
-```@setup bench
-using CSV, DataFrames
-using StatsPlots
-benchdir(args...) = joinpath("..", ".." ,"bench", args...);
-```
-
-
-```@example bench
-table = CSV.File(benchdir("results.csv")) |> DataFrame
-```
-
-```@example bench
-@df table groupedbar(:name, [:psfmodels :astropy];
-    ylabel="time (s)", yscale=:log10, leg=:outertopright,
-    label=["PSFModels.jl" "Astropy"], size=(500, 300))
-```
-
 ## Contributing and Support
 
 If you would like to contribute, feel free to open a [pull request](https://github.com/JuliaAstro/PSFModels.jl/pulls). If you want to discuss something before contributing, head over to [discussions](https://github.com/JuliaAstro/PSFModels.jl/discussions) and join or open a new topic. If you're having problems with something, please open an [issue](https://github.com/JuliaAstro/PSFModels.jl/issues).

--- a/src/PSFModels.jl
+++ b/src/PSFModels.jl
@@ -14,6 +14,14 @@ The following models are currently implemented
 
 In general, the PSFs have a position, a full-width at half-maximum (FWHM) measure, and an amplitude. The position follows a 1-based pixel coordinate system, where `(1, 1)` represents the *center* of the bottom left pixel. This matches the indexing style of Julia as well as DS9, IRAF, SourceExtractor, and WCS. The FWHM is a consistent scale parameter for the models. That means a `gaussian` with a FWHM of 5 will be visually similar to an `airydisk` with a FWHM of 5. All models support a scalar (isotropic) FWHM and a FWHM for each axis (diagonal), as well as arbitrarily rotating the PSF.
 
+!!! warning "Pixel-convention"
+
+    The pixel convention adopted here is that the bottom-left pixel *center* is `(1, 1)`. The column-major memory layout of julia puts the `x` axis as the rows of a matrix and the `y` axis as the columns. In other words, the axes unpack like
+    ```julia
+    xs, ys = axes(image)
+    ```
+
+
 ## Usage
 
 ### Evaluating models
@@ -97,10 +105,10 @@ data = # load data
 stamp_inds = # optionally choose indices to "cutout"
 
 # use an isotropic Gaussian
-params, synthpsf = fit(gaussian, (:x, :y, :fwhm, :amp), 
+params, synthpsf = fit(gaussian, (:x, :y, :fwhm, :amp),
                        [12, 13, 3.2, 0.1], data, stamp_inds)
 # elliptical, rotated Gaussian
-params, synthpsf = fit(gaussian, (:x, :y, :fwhm, :amp, :theta), 
+params, synthpsf = fit(gaussian, (:x, :y, :fwhm, :amp, :theta),
                        [12, 13, 3.2, 3.2, 0.1, 0], data, stamp_inds)
 # obscured Airy disk
 params, synthpsf = fit(airydisk, (:x, :y, :fwhm, :amp, :ratio),

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -62,12 +62,12 @@ func_kwargs = (alpha=2)
 params, synthpsf = PSFModels.fit(moffat, P, psf; func_kwargs)
 ```
 """
-function fit(model::Model, 
-             params, 
-             image::AbstractMatrix{T}, 
-             inds=axes(image); 
-             func_kwargs=(;), 
-             alg=LBFGS(), 
+function fit(model::Model,
+             params,
+             image::AbstractMatrix{T},
+             inds=axes(image);
+             func_kwargs=(;),
+             alg=LBFGS(),
              kwargs...) where T
     _keys = keys(params)
     cartinds = CartesianIndices(inds)
@@ -121,7 +121,7 @@ function generate_params(names, values)
         fwhm = values[_ind], values[_ind + 1]
         first_half = @views zip(names[begin:_ind - 1], values[begin:_ind - 1])
         second_half = @views zip(names[_ind + 1:end], values[_ind + 2:end])
-        return (;first_half..., fwhm, second_half...)        
+        return (;first_half..., fwhm, second_half...)
     end
     return (;zip(names, values)...)
 end

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -2,9 +2,9 @@
 const Model = Union{typeof(gaussian), typeof(normal), typeof(airydisk), typeof(moffat)}
 
 """
-    PSFModels.fit(model, params, X0, image, inds=axes(image); alg=LBFGS(), kwargs...)
+    PSFModels.fit(model, params, image, inds=axes(image); func_kwargs=(;), alg=LBFGS(), kwargs...)
 
-Fit a PSF model (`model`) defined by the given `params` as a collection of symbols, and initial guess vector `X0`, to the data in `image` at the specified `inds` (by default, the entire array). Additional keyword arguments, as well as the fitting algorithm `alg`, are passed to `Optim.optimize`. By default we use forward-mode autodifferentiation (AD) to derive Jacobians for the fitting functions. Refer to the [Optim.jl documentation](https://julianlsolvers.github.io/Optim.jl/stable/) for more information.
+Fit a PSF model (`model`) defined by the given `params` as a named tuple of the parameters to fit and their default values. This model is fit to the data in `image` at the specified `inds` (by default, the entire array). To pass extra keyword arguments to the `model` (i.e., to "freeze" a parameter), pass them in a named tuple to `func_kwargs`. Additional keyword arguments, as well as the fitting algorithm `alg`, are passed to `Optim.optimize`. By default we use forward-mode auto-differentiation (AD) to derive Jacobians for the LBFGS optimization algorithm. Refer to the [Optim.jl documentation](https://julianlsolvers.github.io/Optim.jl/stable/) for more information.
 
 # Choosing parameters
 
@@ -13,36 +13,27 @@ The `fit` function is very powerful because it gives you a great amount of flexi
 ```julia
 model = gaussian
 # match params to arguments of PSF
-params = (:x, :y, :fwhm, :amp)
-# initial-guess vector follows order of `params`
-X0 = [20, 20, 3, 1]
+params = (x=20, y=20, fwhm=3, amp=1)
 ```
 
 Note that `params` can follow any order
 
 ```julia
-params = (:amp, :x, :y, :fwhm)
-X0 = [1, 20, 20, 3]
+params = (amp=1, x=20, y=20, fwhm=3)
 ```
 
-Now, to extend this interface to the bivariate PSF case, where `fwhm` is two values, all you need to do is add an additional entry in the appropriate position in the intial guess vector
+Now, to extend this interface to the bivariate PSF case, where `fwhm` is two values, all you need to do is use a tuple or vector
 
 ```julia
-params = (:x, :y, :fwhm)
-# x, y, fwhmx, fwhmy
-X0 = [20, 20, 3, 3]
+params = (x=20, y=20, fwhm=(3, 3))
 ```
 
 and, again, the order does not matter
 
 ```julia
 model = moffat
-params = (:alpha, :x, :y, :fwhm, :amp)
-# alpha, x, y, fwhmx, fwhmy, amp
-X0 = [1, 20, 20, 3, 3, 10]
+params = (alpha=1, x=20, y=20, fwhm=3, amp=10)
 ```
-    
-As of right now, the only thing you cannot do is "freeze" a parameter (to do that will require writing your own fitting methods and loss functions).
 
 # Fitting a PSF
 
@@ -52,7 +43,7 @@ After selecting your model and parameters, fitting data is easy
 P = (x=12, y=13, fwhm=13.2, amp=0.1)
 psf = gaussian.(CartesianIndicies(1:25, 1:15); P...)
 
-params, synthpsf = PSFModels.fit(gaussian, keys(P), values(P), psf)
+params, synthpsf = PSFModels.fit(gaussian, P, psf)
 ```
 
 here `params` is a named tuple of the best fitting parameters. This allows you to instantly create your best-fitting model like
@@ -62,37 +53,66 @@ model = gaussian(; params...)
 ```
 
 `synthpsf` is the best-fitting model evaluated on the input grid, for direct comparison with the input data.
+
+To alter parameters without fitting them (i.e., "freeze" them) use `func_kwargs`
+
+```julia
+P = (x=12, y=13, fwhm=(12.4, 13.2), amp=0.1)
+func_kwargs = (alpha=2)
+params, synthpsf = PSFModels.fit(moffat, P, psf; func_kwargs)
+```
 """
-function fit(model::Model, params, X0::AbstractVector, image::AbstractMatrix{T}, inds=axes(image); alg=LBFGS(), kwargs...) where T
-    if length(params) == length(X0) && :theta in params
-        throw(ArgumentError("cannot fit theta for isotropic PSF"))
-    end
+function fit(model::Model, 
+             params, 
+             image::AbstractMatrix{T}, 
+             inds=axes(image); 
+             func_kwargs=(;), 
+             alg=LBFGS(), 
+             kwargs...) where T
+    _keys = keys(params)
     cartinds = CartesianIndices(inds)
     function loss(X::AbstractVector{T}) where T
-        P = generate_params(params, X)
+        P = generate_params(_keys, X)
         minind = map(minimum, inds)
         maxind = map(maximum, inds)
         minind[1] - 0.5 ≤ P.x ≤ maxind[1] + 0.5 || return T(Inf)
         minind[2] - 0.5 ≤ P.y ≤ maxind[2] + 0.5 || return T(Inf)
         all(>(0), P.fwhm) || return T(Inf)
-        if :ratio in params
+        if :ratio in _keys
             0 < P.ratio < 1 || return T(Inf)
         end
-        if :theta in params
+        if :theta in _keys
             -45 < P.theta < 45 || return T(Inf)
         end
         # mean square error
         mse = mean(cartinds) do idx
-            resid = model(T, idx; P...) - image[idx]
+            resid = model(T, idx; P..., func_kwargs...) - image[idx]
             return resid^2
         end
         return mse
     end
+    X0 = vector_from_params(T, params)
     result = optimize(loss, X0, alg; autodiff=:forward, kwargs...)
     Optim.converged(result) || @warn "optimizer did not converge" result
     X = Optim.minimizer(result)
-    P_best = generate_params(params, X)
-    return P_best, model.(T, cartinds; P_best...)
+    P_best = generate_params(_keys, X)
+    return P_best, model.(T, cartinds; P_best..., func_kwargs...)
+end
+
+function vector_from_params(T, params)
+    _keys = keys(params)
+    _vals = values(params)
+    if :fwhm in _keys && params.fwhm isa BivariateLike
+        _ind = findfirst(==(:fwhm), _keys)
+        first_half = @views _vals[begin:_ind - 1]
+        fwhmx, fwhmy = _vals[_ind]
+        second_half = @views _vals[_ind + 1:end]
+        return T[first_half..., fwhmx, fwhmy, second_half...]
+    end
+    if :theta in _keys && !(:fwhm isa BivariateLike)
+        throw(ArgumentError("cannot fit theta for isotropic distribution"))
+    end
+    return collect(T, _vals)
 end
 
 function generate_params(names, values)


### PR DESCRIPTION
This changes the implementation of the fitters to be even more flexible by using named tuples for the input parameters.

So previously, where you would write
```
fit(gaussian, (:x, :y, :fwhm), [20, 20, 5.0], psf)
```
you will now write
```
fit(gaussian, (x=20, y=20, fwhm=5), psf)
```

In addition, the new `func_kwargs` allows "freezing" parameters
```
func_kwargs = (; alpha=2)
fit(moffat, (x=20, y=20, fwhm=5), psf; func_kwargs)
```


