### PR TITLE
add background parameter to models

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 CoordinateTransformations = "0.6"

--- a/bench/bench.jl
+++ b/bench/bench.jl
@@ -56,7 +56,7 @@ psf = HCIDatasets.BetaPictoris[:psf]
 jl_times = []
 py_times = []
 
-@info "Gaussian"
+
 P0 = (x=20, y=20, fwhm=(5, 5), amp=0.1)
 t_jl = @belapsed PSFModels.fit(gaussian, $P0, $psf)
 cartinds = CartesianIndices(psf)
@@ -69,9 +69,9 @@ t_py = @belapsed begin
 end
 push!(jl_times, t_jl)
 push!(py_times, t_py)
+@info "Gaussian" PSFModels=t_jl astropy=t_py
 
 
-@info "AiryDisk"
 P0 = (x=20, y=20, fwhm=5, amp=0.1)
 t_jl = @belapsed PSFModels.fit(airydisk, $P0, $psf)
 t_py = @belapsed begin
@@ -81,8 +81,8 @@ t_py = @belapsed begin
 end
 push!(jl_times, t_jl)
 push!(py_times, t_py)
+@info "AiryDisk" PSFModels=t_jl astropy=t_py
 
-@info "Moffat"
 P0 = (x=20, y=20, fwhm=5, amp=0.1)
 t_jl = @belapsed PSFModels.fit(moffat, $P0, $psf)
 t_py = @belapsed begin
@@ -92,7 +92,7 @@ t_py = @belapsed begin
 end
 push!(jl_times, t_jl)
 push!(py_times, t_py)
-
+@info "Moffat" PSFModels=t_jl astropy=t_py
 
 filename = joinpath(@__DIR__, "fitting_results.csv")
 DataFrame(name=names, psfmodels=jl_times, astropy=py_times) |> CSV.write(filename)

--- a/src/PSFModels.jl
+++ b/src/PSFModels.jl
@@ -105,17 +105,17 @@ data = # load data
 stamp_inds = # optionally choose indices to "cutout"
 
 # use an isotropic Gaussian
-params, synthpsf = fit(gaussian, (:x, :y, :fwhm, :amp),
-                       [12, 13, 3.2, 0.1], data, stamp_inds)
+params, synthpsf = fit(gaussian, (x=12, y=13, fwhm=3.2, amp=0.1),
+                       data, stamp_inds)
 # elliptical, rotated Gaussian
-params, synthpsf = fit(gaussian, (:x, :y, :fwhm, :amp, :theta),
-                       [12, 13, 3.2, 3.2, 0.1, 0], data, stamp_inds)
+params, synthpsf = fit(gaussian, (x=12, y=13, fwhm=(3.2, 3.2), amp=0.1, theta=0)
+                       data, stamp_inds)
 # obscured Airy disk
-params, synthpsf = fit(airydisk, (:x, :y, :fwhm, :amp, :ratio),
-                       [12, 13, 3.2, 0.1, 0.3], data, stamp_inds)
+params, synthpsf = fit(airydisk, (x=12, y=13, fwhm=3.2, amp=0.1, ratio=0.3),
+                       data, stamp_inds)
 # bivariate Moffat with arbitrary alpha
-params, synthpsf = fit(moffat, (:x, :y, :fwhm, :amp, :alpha),
-                       [12, 13, 3.2, 3.2, 0.1, 1], data, stamp_inds)
+params, synthpsf = fit(moffat, (x=12, y=13, fwhm=(3.2, 3.2), amp=0.1, alpha=1),
+                       data, stamp_inds)
 ```
 
 ### Plotting

--- a/src/PSFModels.jl
+++ b/src/PSFModels.jl
@@ -137,6 +137,7 @@ using Optim
 using Rotations
 using SpecialFunctions
 using StaticArrays
+using Statistics
 
 export gaussian, normal, airydisk, moffat
 

--- a/src/PSFModels.jl
+++ b/src/PSFModels.jl
@@ -32,8 +32,8 @@ Directly evaluating the functions is the most straightforward way to use this pa
 julia> gaussian(0, 0; x=0, y=0, fwhm=3)
 1.0
 
-julia> gaussian(BigFloat, 0, 0; x=0, y=0, fwhm=3, amp=0.1)
-0.1000000000000000055511151231257827021181583404541015625
+julia> gaussian(BigFloat, 0, 0; x=0, y=0, fwhm=3, amp=0.1, bkg=1)
+1.100000000000000088817841970012523233890533447265625
 ```
 
 We also provide "curried" versions of the functions, which allow you to specify the parameters and evaluate the PSF later

--- a/src/airy.jl
+++ b/src/airy.jl
@@ -3,7 +3,7 @@
     airydisk([T=Float64], point; x, y, fwhm, ratio=0, amp=1, theta=0, bkg=0)
     airydisk([T=Float64], px, py; x, y, fwhm, ratio=0, amp=1, theta=0, bkg=0)
 
-An unnormalized Airy disk. The position can be specified in `(x, y)` coordinates as a `Tuple`, `AbstractVector`, or as separate arguments. If `theta` is given, the PSF will be rotated by `theta` degrees counter-clockwise from the x-axis.
+An unnormalized Airy disk. The position can be specified in `(x, y)` coordinates as a `Tuple`, `AbstractVector`, or as separate arguments. If `theta` is given, the PSF will be rotated by `theta` degrees counter-clockwise from the x-axis. If `bkg` is given it will be added as a scalar to the PSF.
 
 The `fwhm` can be a scalar (isotropic) or a vector/tuple (diagonal). Keep in mind that `theta` has no effect for isotropic distributions and is degenerate with the `fwhm` parameters (i.e., theta=90 is the same as reversing the `fwhm` tuple)
 

--- a/src/airy.jl
+++ b/src/airy.jl
@@ -1,7 +1,7 @@
 
 @doc raw"""
-    airydisk([T=Float64], point; x, y, fwhm, ratio=0, amp=1, theta=0)
-    airydisk([T=Float64], px, py; x, y, fwhm, ratio=0, amp=1, theta=0)
+    airydisk([T=Float64], point; x, y, fwhm, ratio=0, amp=1, theta=0, bkg=0)
+    airydisk([T=Float64], px, py; x, y, fwhm, ratio=0, amp=1, theta=0, bkg=0)
 
 An unnormalized Airy disk. The position can be specified in `(x, y)` coordinates as a `Tuple`, `AbstractVector`, or as separate arguments. If `theta` is given, the PSF will be rotated by `theta` degrees counter-clockwise from the x-axis.
 
@@ -28,13 +28,13 @@ f(x | x̂, FWHM, ϵ) = [ 2J₁(q) / q - 2ϵJ₁(ϵq) / q ]^2 / (1 - ϵ^2)^2
 ```
 where `ϵ` is the ratio (0 ≤ `ϵ` < 1).
 """
-airydisk(T, px, py; x, y, fwhm, ratio=0, amp=one(T), theta=0) = convert(T, _airydisk(px, py, x, y, fwhm, ratio, amp, theta))
+airydisk(T, px, py; x, y, fwhm, ratio=0, amp=one(T), theta=0, bkg=0) = convert(T, _airydisk(px, py, x, y, fwhm, ratio, amp, theta, bkg))
 
 # factor for scaling radius in terms of the fwhm
 const AIRY_PRE = π / 0.973
 
 # isotropic
-function _airydisk(px, py, x, y, fwhm, ratio, amp, theta)
+function _airydisk(px, py, x, y, fwhm, ratio, amp, theta, background)
     # find offset from center
     dx = px - x
     dy = py - y
@@ -43,18 +43,18 @@ function _airydisk(px, py, x, y, fwhm, ratio, amp, theta)
     # unnormalized airydisk
     r = sqrt(dx^2 + dy^2)
     # short-circuit
-    iszero(r) && return amp / (1 - ratio^2)^2
+    iszero(r) && return amp / (1 - ratio^2)^2 + background
     q = AIRY_PRE * r / fwhm
     I1 = 2 * besselj1(q) / q
     if iszero(ratio)
-        return amp * I1^2
+        return amp * I1^2 + background
     end
     I2 = 2 * ratio * besselj1(q * ratio) / q
-    return amp * ((I1 - I2) / (1 - ratio^2))^2
+    return amp * ((I1 - I2) / (1 - ratio^2))^2 + background
 end
 
 # bivariate
-function _airydisk(px, py, x, y, fwhm::BivariateLike, ratio, amp, theta)
+function _airydisk(px, py, x, y, fwhm::BivariateLike, ratio, amp, theta, background)
     # find offset from center
     dx = px - x
     dy = py - y
@@ -66,11 +66,11 @@ function _airydisk(px, py, x, y, fwhm::BivariateLike, ratio, amp, theta)
     fwhmx, fwhmy = fwhm
     q = AIRY_PRE * sqrt((dx / fwhmx)^2 + (dy / fwhmy)^2)
     # short-circuit
-    iszero(q) && return amp / (1 - ratio^2)^2
+    iszero(q) && return amp / (1 - ratio^2)^2 + background
     I1 = 2 * besselj1(q) / q
     if iszero(ratio)
-        return amp * I1^2
+        return amp * I1^2 + background
     end
     I2 = 2 * ratio * besselj1(q * ratio) / q
-    return amp * ((I1 - I2) / (1 - ratio^2))^2
+    return amp * ((I1 - I2) / (1 - ratio^2))^2 + background
 end

--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -75,10 +75,10 @@ function fit(model::Model,
              kwargs...) where T
     _keys = keys(params)
     cartinds = CartesianIndices(inds)
+    minind = map(minimum, inds)
+    maxind = map(maximum, inds)
     function _loss(X::AbstractVector{T}) where T
         P = generate_params(_keys, X)
-        minind = map(minimum, inds)
-        maxind = map(maximum, inds)
         minind[1] - 0.5 ≤ P.x ≤ maxind[1] + 0.5 || return T(Inf)
         minind[2] - 0.5 ≤ P.y ≤ maxind[2] + 0.5 || return T(Inf)
         all(0 .< P.fwhm .< maxfwhm) || return T(Inf)
@@ -88,8 +88,8 @@ function fit(model::Model,
         if :theta in _keys
             -45 < P.theta < 45 || return T(Inf)
         end
-        # sum of errors (by default, with L2 norm == chi-squared)
-        mse = sum(cartinds) do idx
+        # mean of errors (by default, with L2 norm == chi-squared)
+        mse = mean(cartinds) do idx
             resid = model(T, idx; P..., func_kwargs...) - image[idx]
             return loss(resid)
         end

--- a/src/gaussian.jl
+++ b/src/gaussian.jl
@@ -3,7 +3,7 @@
     gaussian([T=Float64], point; x, y, fwhm, amp=1, theta=0, bkg=0)
     gaussian([T=Float64], px, py; x, y, fwhm, amp=1, theta=0, bkg=0)
 
-An unnormalized bivariate Gaussian distribution. The position can be specified in `(x, y)` coordinates as a `Tuple`, `AbstractVector`, or as separate arguments. If `theta` is given, the PSF will be rotated by `theta` degrees counter-clockwise from the x-axis.
+An unnormalized bivariate Gaussian distribution. The position can be specified in `(x, y)` coordinates as a `Tuple`, `AbstractVector`, or as separate arguments. If `theta` is given, the PSF will be rotated by `theta` degrees counter-clockwise from the x-axis. If `bkg` is given it will be added as a scalar to the PSF.
 
 The `fwhm` can be a scalar (isotropic) or a vector/tuple (diagonal). Keep in mind that `theta` has no effect for isotropic distributions and is degenerate with the `fwhm` parameters (i.e., theta=90 is the same as reversing the `fwhm` tuple)
 

--- a/src/gaussian.jl
+++ b/src/gaussian.jl
@@ -1,7 +1,7 @@
 
 @doc raw"""
-    gaussian([T=Float64], point; x, y, fwhm, amp=1, theta=0)
-    gaussian([T=Float64], px, py; x, y, fwhm, amp=1, theta=0)
+    gaussian([T=Float64], point; x, y, fwhm, amp=1, theta=0, bkg=0)
+    gaussian([T=Float64], px, py; x, y, fwhm, amp=1, theta=0, bkg=0)
 
 An unnormalized bivariate Gaussian distribution. The position can be specified in `(x, y)` coordinates as a `Tuple`, `AbstractVector`, or as separate arguments. If `theta` is given, the PSF will be rotated by `theta` degrees counter-clockwise from the x-axis.
 
@@ -13,7 +13,7 @@ f(x | x̂, FWHM) = exp[-4ln(2) * ||x - x̂|| / FWHM^2]
 ```
 where `x̂` and `x` are position vectors (indices) `||⋅||` represents the square-distance, and `FWHM` is the full width at half-maximum. If `FWHM` is a scalar, the Gaussian distribution will be isotropic. If `FWHM` is a vector or tuple, the weighting is applied along each axis (diagonal).
 """
-gaussian(T, px, py; x, y, fwhm, amp=one(T), theta=0) = convert(T, _gaussian(px, py, x, y, fwhm, amp, theta))
+gaussian(T, px, py; x, y, fwhm, amp=one(T), theta=0, bkg=0) = convert(T, _gaussian(px, py, x, y, fwhm, amp, theta, bkg))
 
 
 """
@@ -27,7 +27,7 @@ const normal = gaussian
 const GAUSS_PRE = -4 * log(2)
 
 # isotropic
-function _gaussian(px, py, x, y, fwhm, amp, theta)
+function _gaussian(px, py, x, y, fwhm, amp, theta, background)
     # find offset from center
     dx = px - x
     dy = py - y
@@ -36,11 +36,11 @@ function _gaussian(px, py, x, y, fwhm, amp, theta)
     # unnormalized gaussian likelihood
     sqmahab = dx^2 + dy^2
     sqmahab /= fwhm^2
-    return amp * exp(GAUSS_PRE * sqmahab)
+    return amp * exp(GAUSS_PRE * sqmahab) + background
 end
 
 # bivariate
-function _gaussian(px, py, x, y, fwhm::BivariateLike, amp, theta)
+function _gaussian(px, py, x, y, fwhm::BivariateLike, amp, theta, background)
     # find offset from center
     dx = px - x
     dy = py - y
@@ -51,5 +51,5 @@ function _gaussian(px, py, x, y, fwhm::BivariateLike, amp, theta)
     # unnormalized gaussian likelihood
     fwhmx, fwhmy = fwhm
     sqmahab = (dx / fwhmx)^2 + (dy / fwhmy)^2
-    return amp * exp(GAUSS_PRE * sqmahab)
+    return amp * exp(GAUSS_PRE * sqmahab) + background
 end

--- a/src/moffat.jl
+++ b/src/moffat.jl
@@ -1,7 +1,7 @@
 
 @doc raw"""
-    moffat([T=Float64], point; x, y, fwhm, alpha=1, amp=1, theta=0)
-    moffat([T=Float64], px, py; x, y, fwhm, alpha=1, amp=1, theta=0)
+    moffat([T=Float64], point; x, y, fwhm, alpha=1, amp=1, theta=0, bkg=0)
+    moffat([T=Float64], px, py; x, y, fwhm, alpha=1, amp=1, theta=0, bkg=0)
 
 Two dimensional Moffat model. The position can be specified in `(x, y)` coordinates as a `Tuple`, `AbstractVector`, or as separate arguments. If `theta` is given, the PSF will be rotated by `theta` degrees counter-clockwise from the x-axis.
 
@@ -13,10 +13,10 @@ f(x | x̂, FWHM, α) = A / (1 + ||x - x̂|| / (FWHM / 2)^2)^α
 ```
 where `x̂` and `x` are position vectors (indices) `||⋅||` represents the square-distance, and `FWHM` is the full width at half-maximum. If `FWHM` is a vector or tuple, the weighting is applied along each axis.
 """
-moffat(T, px, py; x, y, fwhm, alpha=1, amp=one(T), theta=0) = convert(T, _moffat(px, py, x, y, fwhm, alpha, amp, theta))
+moffat(T, px, py; x, y, fwhm, alpha=1, amp=one(T), theta=0, bkg=0) = convert(T, _moffat(px, py, x, y, fwhm, alpha, amp, theta, bkg))
 
 # isotropic
-function _moffat(px, py, x, y, fwhm, alpha, amp, theta)
+function _moffat(px, py, x, y, fwhm, alpha, amp, theta, background)
     # find offset from center
     dx = px - x
     dy = py - y
@@ -25,11 +25,11 @@ function _moffat(px, py, x, y, fwhm, alpha, amp, theta)
     # unnormalized moffat
     dist = dx^2 + dy^2
     dist /= (fwhm / 2)^2
-    return amp / (1 + dist)^alpha
+    return amp / (1 + dist)^alpha + background
 end
 
 # bivariate
-function _moffat(px, py, x, y, fwhm::BivariateLike, alpha, amp, theta)
+function _moffat(px, py, x, y, fwhm::BivariateLike, alpha, amp, theta, background)
     # find offset from center
     dx = px - x
     dy = py - y
@@ -41,5 +41,5 @@ function _moffat(px, py, x, y, fwhm::BivariateLike, alpha, amp, theta)
     fwhmx, fwhmy = fwhm
     # unnormalized moffat
     dist = (dx / (fwhmx/2))^2 + (dy / (fwhmy/2))^2
-    return amp / (1 + dist)^alpha
+    return amp / (1 + dist)^alpha + background
 end

--- a/src/moffat.jl
+++ b/src/moffat.jl
@@ -3,7 +3,7 @@
     moffat([T=Float64], point; x, y, fwhm, alpha=1, amp=1, theta=0, bkg=0)
     moffat([T=Float64], px, py; x, y, fwhm, alpha=1, amp=1, theta=0, bkg=0)
 
-Two dimensional Moffat model. The position can be specified in `(x, y)` coordinates as a `Tuple`, `AbstractVector`, or as separate arguments. If `theta` is given, the PSF will be rotated by `theta` degrees counter-clockwise from the x-axis.
+Two dimensional Moffat model. The position can be specified in `(x, y)` coordinates as a `Tuple`, `AbstractVector`, or as separate arguments. If `theta` is given, the PSF will be rotated by `theta` degrees counter-clockwise from the x-axis. If `bkg` is given it will be added as a scalar to the PSF.
 
 The `fwhm` can be a scalar (isotropic) or a vector/tuple (diagonal). Keep in mind that `theta` has no effect for isotropic distributions and is degenerate with the `fwhm` parameters (i.e., theta=90 is the same as reversing the `fwhm` tuple)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,11 @@ function test_model_interface(K)
     val_dir = @inferred K(0, 0; x=0, y=0, amp=2.0, fwhm=9)
     @test m(0, 0) ≈ val_dir ≈ 2.0
 
+    # test background
+    m = K(x=0, y=0, fwhm=9, bkg=10)
+    val_dir = @inferred K(0, 0; x=0, y=0, fwhm=9, bkg=10)
+    @test m(0, 0) ≈ val_dir ≈ 11
+
     # test different type
     m = K(BigFloat; x=0, y=0, fwhm=10)
     val_dir = @inferred K(BigFloat, 0, 0; x=0, y=0, fwhm=10)


### PR DESCRIPTION
This adds `bkg` as an optional parameter for each model. This can be convenient for avoiding background subtraction biasing fitting results.
