### PR TITLE
Remove line hidden in example

### DIFF
--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -146,7 +146,6 @@ Finally, we provide plotting recipes (`psfplot`/`psfplot!`) from
 seen in use in the [API/Reference](@ref) section.
 
 ```julia
-using PSFModels # hide
 using Plots
 
 model = gaussian(x=0, y=0, fwhm=(8, 10), theta=12)


### PR DESCRIPTION
`# hide` comment not necessary in regular code blocks