### PR TITLE
Update to new `Optim.Options` interface

### DIFF
--- a/src/fitting.jl
+++ b/src/fitting.jl
@@ -16,7 +16,7 @@ this to the L1 norm, for example, by passing `loss=abs`. The maximum FWHM can be
 set with `maxfwhm` as a number or tuple.
 
 Additional keyword arguments, as well as the fitting algorithm `alg`, are passed
-to `Optim.optimize`. By default we use forward-mode auto-differentiation (AD) to
+to `Optim.optimize` as an `Optim.Option`. By default we use forward-mode auto-differentiation (AD) to
 derive Jacobians for the
 [Newton with Trust Region](https://julianlsolvers.github.io/Optim.jl/stable/#algo/newton_trust_region/)
 optimization algorithm. Refer to the
@@ -96,7 +96,7 @@ function fit(model::Model,
 
     _loss = build_loss_function(model, params, image, inds; func_kwargs, loss, maxfwhm)
     X0 = vector_from_params(T, params)
-    result = optimize(_loss, X0, alg; autodiff=:forward, kwargs...)
+    result = optimize(_loss, X0, alg, Optim.Options(; kwargs...); autodiff=:forward)
     Optim.converged(result) || @warn "optimizer did not converge" result
     X = Optim.minimizer(result)
     P_best = generate_params(_keys, X)

--- a/test/fitting.jl
+++ b/test/fitting.jl
@@ -14,7 +14,7 @@ function test_fitting(rng, model, params, inds; kwargs...)
     # perturb starting guess by a little
     _vals .*= 1 .+ 1e-2 .* randn(rng, length(_vals))
     P0 = PSFModels.generate_params(_keys, _vals)
-    P, bestfit = fit(model, P0, psf; kwargs...)
+    P, bestfit = fit(model, P0, psf; x_abstol = 5e-5, kwargs...)
     for k in _keys
         if P[k] isa Tuple
             @test P[k][1] ≈ params[k][1] rtol=1e-2


### PR DESCRIPTION
Just noticed that Optim.jl kwargs being passed to `PSFModels.fit` were being ignored, probs due to https://github.com/JuliaNLSolvers/Optim.jl/issues/243

This PR updates how we pass Optim kwargs to pass this new interface, and also includes it in our fitting tests