### PR TITLE
Enclose all tests in larger testset

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,100 +61,102 @@ function test_model_interface(K)
     @test m(0, 0) ≈ val_dir ≈ BigFloat(1)
 end
 
-@testset "Model Interface - $K" for K in (gaussian, airydisk, moffat)
-    test_model_interface(K)
-end
-
-@testset "gaussian" begin
-    m = gaussian(x=0, y=0, fwhm=10)
-    expected = exp(-4 * log(2) * sum(abs2, SA[1, 2]) / 100)
-    @test m(1, 2) ≈ expected
-
-    m = gaussian(x=0, y=0, fwhm=(10, 9))
-    wdist = (1/10)^2 + (2/9)^2
-    expected = exp(-4 * log(2) * wdist)
-    @test m(1, 2) ≈ expected
-
-    # test Normal alias
-    @test normal(0, 0; x=0, y=0, fwhm=10) === gaussian(0, 0; x=0, y=0, fwhm=10)
-end
-
-
-@testset "airydisk" begin
-    fwhm = 10
-    m = airydisk(x=0, y=0, fwhm=fwhm)
-    ld = fwhm / 1.028
-    radius = 1.22 * ld
-    # first radius is 0
-    @test m(radius, 0) ≈ 0 atol=1e-5
-    @test m(-radius, 0) ≈ 0 atol=1e-5
-    @test m(0, radius) ≈ 0 atol=1e-5
-    @test m(0, -radius) ≈ 0 atol=1e-5
-
-    # second radius is 0
-    radius2 = 2.23 * ld
-    @test m(radius2, 0) ≈ 0 atol=1e-5
-    @test m(-radius2, 0) ≈ 0 atol=1e-5
-    @test m(0, radius2) ≈ 0 atol=1e-5
-    @test m(0, -radius2) ≈ 0 atol=1e-5
-
-    fwhm = (10, 6)
-    m = airydisk(x=0, y=0, fwhm=fwhm)
-    r1 = fwhm[1] * 1.18677
-    r2 = fwhm[2] * 1.18677
-    # first radius is 0
-    @test m(r1, 0) ≈ 0 atol=1e-5
-    @test m(-r1, 0) ≈ 0 atol=1e-5
-    @test m(0, r2) ≈ 0 atol=1e-5
-    @test m(0, -r2) ≈ 0 atol=1e-5
-
-    # test with ratio
-    mratio = airydisk(x=0, y=0, fwhm=10, amp=1, ratio=sqrt(0.5))
-    # test attenuation
-    @test mratio(0, 0) ≈ 1
-    @test mratio(radius, 0) > m(radius, 0)
-    @test mratio(-radius, 0) > m(-radius, 0)
-    @test mratio(0, radius) > m(0, radius)
-    @test mratio(0, -radius) > m(0, -radius)
-
-
-    mratio = airydisk(x=0, y=0, fwhm=(10, 6), ratio=sqrt(0.5), amp=4)
-    r1 = fwhm[1] * 1.18677
-    r2 = fwhm[2] * 1.18677
-    # test attenuation
-    @test mratio(0, 0) ≈ 4
-    @test mratio(r1, 0) > m(r1, 0)
-    @test mratio(-r1, 0) > m(-r1, 0)
-    @test mratio(0, r2) > m(0, r2)
-    @test mratio(0, -r2) > m(0, -r2)
-
-    # https://github.com/JuliaAstro/PSFModels.jl/issues/14
-    mratio = airydisk(x = 40.5, y=40.5, fwhm=10, ratio=0.2,amp=1)
-    @test mratio(40.5, 40.5) ≈ 1
-end
-
-@testset "moffat" begin
-    m = moffat(x=0, y=0, fwhm=10)
-     expected = inv(1 + sum(abs2, SA[1, 2]) / 25)
-    @test m(1, 2) ≈ expected
-
-    m = moffat(x=0, y=0, fwhm=(10, 9))
-    wdist = (1/5)^2 + (2/4.5)^2
-    expected = inv(1 + wdist)
-    @test m(1, 2) ≈ expected
-
-    # different alpha
-    m = moffat(x=0, y=0, fwhm=10, alpha=2)
-    expected = inv(1 + sum(abs2, SA[1, 2] ./  PSFModels._moffat_fwhm_to_gamma(10, 2)))^2
-    @test m(1, 2) ≈ expected
-
-    fwhms = randn(rng, 100) .+ 10
-    for alpha in [0.5, 1.0, 1.5]
-        gammas = PSFModels._moffat_fwhm_to_gamma.(fwhms, alpha)
-        fwhm_calc = PSFModels._moffat_gamma_to_fwhm.(gammas, alpha)
-        @test fwhms ≈ fwhm_calc
+@testset "PSFModels" begin
+    @testset "Model Interface - $K" for K in (gaussian, airydisk, moffat)
+        test_model_interface(K)
     end
-end
+    
+    @testset "gaussian" begin
+        m = gaussian(x=0, y=0, fwhm=10)
+        expected = exp(-4 * log(2) * sum(abs2, SA[1, 2]) / 100)
+        @test m(1, 2) ≈ expected
+    
+        m = gaussian(x=0, y=0, fwhm=(10, 9))
+        wdist = (1/10)^2 + (2/9)^2
+        expected = exp(-4 * log(2) * wdist)
+        @test m(1, 2) ≈ expected
+    
+        # test Normal alias
+        @test normal(0, 0; x=0, y=0, fwhm=10) === gaussian(0, 0; x=0, y=0, fwhm=10)
+    end
+    
+    
+    @testset "airydisk" begin
+        fwhm = 10
+        m = airydisk(x=0, y=0, fwhm=fwhm)
+        ld = fwhm / 1.028
+        radius = 1.22 * ld
+        # first radius is 0
+        @test m(radius, 0) ≈ 0 atol=1e-5
+        @test m(-radius, 0) ≈ 0 atol=1e-5
+        @test m(0, radius) ≈ 0 atol=1e-5
+        @test m(0, -radius) ≈ 0 atol=1e-5
+    
+        # second radius is 0
+        radius2 = 2.23 * ld
+        @test m(radius2, 0) ≈ 0 atol=1e-5
+        @test m(-radius2, 0) ≈ 0 atol=1e-5
+        @test m(0, radius2) ≈ 0 atol=1e-5
+        @test m(0, -radius2) ≈ 0 atol=1e-5
+    
+        fwhm = (10, 6)
+        m = airydisk(x=0, y=0, fwhm=fwhm)
+        r1 = fwhm[1] * 1.18677
+        r2 = fwhm[2] * 1.18677
+        # first radius is 0
+        @test m(r1, 0) ≈ 0 atol=1e-5
+        @test m(-r1, 0) ≈ 0 atol=1e-5
+        @test m(0, r2) ≈ 0 atol=1e-5
+        @test m(0, -r2) ≈ 0 atol=1e-5
+    
+        # test with ratio
+        mratio = airydisk(x=0, y=0, fwhm=10, amp=1, ratio=sqrt(0.5))
+        # test attenuation
+        @test mratio(0, 0) ≈ 1
+        @test mratio(radius, 0) > m(radius, 0)
+        @test mratio(-radius, 0) > m(-radius, 0)
+        @test mratio(0, radius) > m(0, radius)
+        @test mratio(0, -radius) > m(0, -radius)
+    
+    
+        mratio = airydisk(x=0, y=0, fwhm=(10, 6), ratio=sqrt(0.5), amp=4)
+        r1 = fwhm[1] * 1.18677
+        r2 = fwhm[2] * 1.18677
+        # test attenuation
+        @test mratio(0, 0) ≈ 4
+        @test mratio(r1, 0) > m(r1, 0)
+        @test mratio(-r1, 0) > m(-r1, 0)
+        @test mratio(0, r2) > m(0, r2)
+        @test mratio(0, -r2) > m(0, -r2)
+    
+        # https://github.com/JuliaAstro/PSFModels.jl/issues/14
+        mratio = airydisk(x = 40.5, y=40.5, fwhm=10, ratio=0.2,amp=1)
+        @test mratio(40.5, 40.5) ≈ 1
+    end
+    
+    @testset "moffat" begin
+        m = moffat(x=0, y=0, fwhm=10)
+         expected = inv(1 + sum(abs2, SA[1, 2]) / 25)
+        @test m(1, 2) ≈ expected
+    
+        m = moffat(x=0, y=0, fwhm=(10, 9))
+        wdist = (1/5)^2 + (2/4.5)^2
+        expected = inv(1 + wdist)
+        @test m(1, 2) ≈ expected
+    
+        # different alpha
+        m = moffat(x=0, y=0, fwhm=10, alpha=2)
+        expected = inv(1 + sum(abs2, SA[1, 2] ./  PSFModels._moffat_fwhm_to_gamma(10, 2)))^2
+        @test m(1, 2) ≈ expected
+    
+        fwhms = randn(rng, 100) .+ 10
+        for alpha in [0.5, 1.0, 1.5]
+            gammas = PSFModels._moffat_fwhm_to_gamma.(fwhms, alpha)
+            fwhm_calc = PSFModels._moffat_gamma_to_fwhm.(gammas, alpha)
+            @test fwhms ≈ fwhm_calc
+        end
+    end
 
-include("plotting.jl")
-include("fitting.jl")
+    include("plotting.jl")
+    include("fitting.jl")
+end


### PR DESCRIPTION
That way, even if any test errors, all other tests in different testsets still run. Also, in case of success, more compact output.